### PR TITLE
Тонкая настройка отдельных виртуалок

### DIFF
--- a/cvem/connectors/one/OpenNebula.py
+++ b/cvem/connectors/one/OpenNebula.py
@@ -49,8 +49,8 @@ class HISTORY_RECORDS(XMLObject):
 	tuples_lists = { 'HISTORY': HISTORY }
 
 class USER_TEMPLATE(XMLObject):
-		values = [ 'MEM_FREE', 'MEM_TOTAL', 'MEM_TOTAL_REAL', 'MIN_FREE_MEM', 'MEM_OVER', 'TIMESTAMP']
-		numeric = [ 'MEM_FREE', 'MEM_TOTAL', 'MEM_TOTAL_REAL', 'MIN_FREE_MEM', 'MEM_OVER',  'TIMESTAMP']
+		values = [ 'MEM_FREE', 'MEM_TOTAL', 'MEM_TOTAL_REAL', 'MIN_FREE_MEM', 'MEM_OVER', 'TIMESTAMP', 'VAMP_DISABLE', 'VAMP_MIN_TOTAL_MEM', 'VAMP_MAX_TOTAL_MEM', 'VAMP_DO_NOT_MIGRATE', 'VAMP_FORCE_INCREASE'
+		numeric = [ 'MEM_FREE', 'MEM_TOTAL', 'MEM_TOTAL_REAL', 'MIN_FREE_MEM', 'MEM_OVER',  'TIMESTAMP', 'VAMP_DISABLE', 'VAMP_MIN_TOTAL_MEM', 'VAMP_MAX_TOTAL_MEM', 'VAMP_DO_NOT_MIGRATE', 'VAMP_FORCE_INCREASE']
 
 class VM(XMLObject):
 		STATE_INIT=0
@@ -159,6 +159,8 @@ class OpenNebula(CMPInfo):
 					host = HostInfo(int(vm.HISTORY_RECORDS.HISTORY[0].HID), vm.HISTORY_RECORDS.HISTORY[0].HOSTNAME)
 					new_vm = VirtualMachineInfo(int(vm.ID), host, int(vm.TEMPLATE.MEMORY) * 1024, vm)
 					new_vm.user_id = vm.UID
+					if vm.USER_TEMPLATE.VAMP_DISABLE:
+						continue
 					if vm.USER_TEMPLATE.MEM_TOTAL:
 						# to make it work on all ONE versions
 						real_memory = vm.TEMPLATE.REALMEMORY
@@ -173,6 +175,14 @@ class OpenNebula(CMPInfo):
 							new_vm.mem_over_ratio = vm.USER_TEMPLATE.MEM_OVER
 						if vm.USER_TEMPLATE.TIMESTAMP:
 							new_vm.timestamp = vm.USER_TEMPLATE.TIMESTAMP
+						if vm.USER_TEMPLATE.VAMP_MIN_TOTAL_MEM:
+							new_vm.min_total_memory = vm.USER_TEMPLATE.VAMP_MIN_TOTAL_MEM
+						if vm.USER_TEMPLATE.VAMP_MAX_TOTAL_MEM:
+							new_vm.max_total_memory = vm.USER_TEMPLATE.VAMP_MAX_TOTAL_MEM
+						if vm.USER_TEMPLATE.VAMP_DO_NOT_MIGRATE:
+							new_vm.do_not_migrate = True
+						if vm.USER_TEMPLATE.VAMP_FORCE_INCREASE:
+							new_vm.force_increase = True
 
 						# publish MEM properties to the VM user template to show the values to the user
 						OpenNebula._publish_mem_info(new_vm)

--- a/cvem/cvem/CMPInfo.py
+++ b/cvem/cvem/CMPInfo.py
@@ -90,6 +90,14 @@ class VirtualMachineInfo:
 		"""
 		self.raw = raw
 		""" Data of the VM in the original format of the CMP """
+        self.min_total_memory = None
+        """ If VAMP_MIN_TOTAL_MEM is defined in USER_TEMPLATE, it is the lower bound of this VM's total memory instead of Config.MEM_MIN """
+        self.max_total_memory = None
+        """ If VAMP_MAX_TOTAL_MEM is defined in USER_TEMPLATE, it is the upper bound of this VM's total memory instead of VM's original memory """
+        self.do_not_migrate = False
+        """ If VAMP_DO_NOT_MIGRATE is defined in USER_TEMPLATE, do not attempt to migrate this VM (even if Config.MIGRATION is true)."""
+        self.force_increase = False
+        """ If VAMP_FORCE_INCREASE is defined in USER_TEMPLATE, ignore lack of host free memory when increasing (even if Config.FORCE_INCREASE_MEMORY is false) """
 	
 	def set_memory_values(self, real_memory, total_memory, free_memory):
 		"""


### PR DESCRIPTION
Добавлены новые параметры, которые можно указывать в шаблоне виртуалок
для переопределения глобальных параметров конфига CloudVamp.

Все параметры имеют числовые значения (1 и 0 для флагов, целое число
килобайт для "*MEM").

Из консоли для живой виртуалки можно установить эти параметры через
команду `onevm update <vm_id>`.

VAMP_DISABLE
    1: CloudVAMP не будет видеть эту виртуалку, не будет писать про неё
       ничего в лог, не будет ничего у неё менять.
    0: по умолчанию.

VAMP_MIN_TOTAL_MEM
    > 0: минимальный размер общей памяти (свободной + занятой) для этой виртуалки.
         Переопределяет параметр глобального конфига MEM_MIN.
    0: по умолчанию (то есть используется MEM_MIN из конфига)

VAMP_MAX_TOTAL_MEM
    > 0: максимальный размер общей памяти (свободной + занятой) для этой виртуалки.
         Переопределяет изначальный размер памяти виртуалки, с которой
         она была создана.
    0: по умолчанию (то есть CloudVAMP никогда не делает виртуалку жирнее её
       первоначального размера)

VAMP_DO_NOT_MIGRATE
    1: CloudVAMP не будет пытаться мигрировать эту виртуалку, даже если
       очень захочется. Даже если в конфиге указано MIGRATE = True.
    0: по умолчанию (то есть CloudVAMP руководствуется параметром
       MIGRATE).

VAMP_FORCE_INCREASE
    1: CloudVAMP закроет глаза на отсутствие свободной памяти на
       хост-машине при попытках увеличить память виртуалки. Даже если в
       конфиге указано FORCE_INCREASE_MEMORY = False.
    0: по умолчанию (то есть CloudVAMP руководствуется параметром
       FORCE_INCREASE_MEMORY).